### PR TITLE
Resolve systemd-cgroup issue on CentOS7

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -26,7 +26,11 @@ platforms:
         - mv /sbin/initctl.distrib /sbin/initctl
   - name: centos-7
     driver_config:
-      run_command: /sbin/init
+      image: centos/systemd
+      run_command: /usr/sbin/init
+      provision_command:
+        - sed -i 's/UsePAM yes/UsePAM no/g' /etc/ssh/sshd_config
+        - systemctl enable sshd.service
   - name: centos-6
     driver_config:
       run_command: /sbin/init

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 sudo: required
 
+dist: bionic
+
 addons:
   apt:
     sources:
-      - sourceline: "deb https://packages.chef.io/repos/apt/current trusty main"
+      - sourceline: "deb https://packages.chef.io/repos/apt/current bionic main"
     packages:
       - chefdk
 


### PR DESCRIPTION
`systemd start chronyd` failed to start chrony daemon in docker environment.
It was because systemd tried to write PID file in `/run/chrony/chronyd.pid`, which is out of cgroup scope with default CentOS image.
Using `centos/systemd` resolves this issue (https://github.com/test-kitchen/kitchen-docker/issues/268)

```console
[kitchen@7306dfe8de5c ~]$ sudo systemctl start chronyd                                                                                                                                                     
Job for chronyd.service failed because a timeout was exceeded. See "systemctl status chronyd.service" and "journalctl -xe" for details.
```

```console
[kitchen@7306dfe8de5c ~]$ sudo systemctl status chronyd
● chronyd.service - NTP client/server
   Loaded: loaded (/usr/lib/systemd/system/chronyd.service; enabled; vendor preset: enabled)
   Active: failed (Result: timeout) since Sat 2020-01-25 14:51:03 UTC; 6s ago
     Docs: man:chronyd(8)
           man:chrony.conf(5)
  Process: 5146 ExecStartPost=/usr/libexec/chrony-helper update-daemon (code=exited, status=0/SUCCESS)
  Process: 5143 ExecStart=/usr/sbin/chronyd $OPTIONS (code=exited, status=0/SUCCESS)

Jan 25 14:49:31 7306dfe8de5c chronyd[5145]: System's initial offset : 0.000509 seconds fast of true (slew)
Jan 25 14:49:33 7306dfe8de5c systemd[1]: Refusing to accept PID outside of service control group, acquired through unsafe symlink chain: /var/run/chrony/chronyd.pid
Jan 25 14:49:33 7306dfe8de5c systemd[1]: Refusing to accept PID outside of service control group, acquired through unsafe symlink chain: /var/run/chrony/chronyd.pid
Jan 25 14:49:33 7306dfe8de5c systemd[1]: Refusing to accept PID outside of service control group, acquired through unsafe symlink chain: /var/run/chrony/chronyd.pid
Jan 25 14:49:46 7306dfe8de5c chronyd[5145]: Selected source 133.243.238.163
Jan 25 14:51:03 7306dfe8de5c systemd[1]: chronyd.service start-post operation timed out. Stopping.
Jan 25 14:51:03 7306dfe8de5c chronyd[5145]: chronyd exiting
Jan 25 14:51:03 7306dfe8de5c systemd[1]: Failed to start NTP client/server.
Jan 25 14:51:03 7306dfe8de5c systemd[1]: Unit chronyd.service entered failed state.
Jan 25 14:51:03 7306dfe8de5c systemd[1]: chronyd.service failed.
```

```console
[kitchen@7306dfe8de5c ~]$ sudo systemctl start chronyd                                                                                                                                                     
Job for chronyd.service failed because a timeout was exceeded. See "systemctl status chronyd.service" and "journalctl -xe" for details.
[kitchen@7306dfe8de5c ~]$ sudo systemctl status chronyd
● chronyd.service - NTP client/server
   Loaded: loaded (/usr/lib/systemd/system/chronyd.service; enabled; vendor preset: enabled)
   Active: failed (Result: timeout) since Sat 2020-01-25 14:51:03 UTC; 6s ago
     Docs: man:chronyd(8)
           man:chrony.conf(5)
  Process: 5146 ExecStartPost=/usr/libexec/chrony-helper update-daemon (code=exited, status=0/SUCCESS)
  Process: 5143 ExecStart=/usr/sbin/chronyd $OPTIONS (code=exited, status=0/SUCCESS)

Jan 25 14:49:31 7306dfe8de5c chronyd[5145]: System's initial offset : 0.000509 seconds fast of true (slew)
Jan 25 14:49:33 7306dfe8de5c systemd[1]: Refusing to accept PID outside of service control group, acquired through unsafe symlink chain: /var/run/chrony/chronyd.pid
Jan 25 14:49:33 7306dfe8de5c systemd[1]: Refusing to accept PID outside of service control group, acquired through unsafe symlink chain: /var/run/chrony/chronyd.pid
Jan 25 14:49:33 7306dfe8de5c systemd[1]: Refusing to accept PID outside of service control group, acquired through unsafe symlink chain: /var/run/chrony/chronyd.pid
Jan 25 14:49:46 7306dfe8de5c chronyd[5145]: Selected source 133.243.238.163
Jan 25 14:51:03 7306dfe8de5c systemd[1]: chronyd.service start-post operation timed out. Stopping.
Jan 25 14:51:03 7306dfe8de5c chronyd[5145]: chronyd exiting
Jan 25 14:51:03 7306dfe8de5c systemd[1]: Failed to start NTP client/server.
Jan 25 14:51:03 7306dfe8de5c systemd[1]: Unit chronyd.service entered failed state.
Jan 25 14:51:03 7306dfe8de5c systemd[1]: chronyd.service failed.
```

Also, [default build environment changed from Trusty to Xenial in TravisCI](https://changelog.travis-ci.com/xenial-as-the-default-build-environment-99476).
I chose to run all tests on Bionic, with newer environment.