### PR TITLE
Ignore `doc` directory during cookbook upload

### DIFF
--- a/chefignore
+++ b/chefignore
@@ -93,6 +93,7 @@ CONTRIBUTING*
 CHANGELOG*
 TESTING*
 MAINTAINERS.toml
+doc
 
 # Strainer #
 ############


### PR DESCRIPTION
Hi! 

We noticed that the `doc` directory is also being uploaded when pushing to Supermarket. This breaks one of our workflows as it should not be included in the Supermarket artifact.

Could you be so kind as to review this and release a new Supermarket version with this directory for us? 

Thanks in advance!